### PR TITLE
DAKEFPVH743PRO: deconflict ADC and LED DMA

### DIFF
--- a/src/main/target/DAKEFPVH743PRO/target.c
+++ b/src/main/target/DAKEFPVH743PRO/target.c
@@ -55,7 +55,7 @@ timerHardware_t timerHardware[] = {
     DEF_TIM(TIM4,  CH4, PD15, TIM_USE_OUTPUT_AUTO, 0, 0),   // S4
     DEF_TIM(TIM15, CH1, PE5,   TIM_USE_ANY, 0, 0),  // CAMERA_CONTROL_PIN
     DEF_TIM(TIM15, CH2, PE6,   TIM_USE_ANY, 0, 0),  // GYRO_1_CLKIN_PIN
-    DEF_TIM(TIM3,  CH3, PB0,   TIM_USE_LED, 0, 0), // LED_2812
+    DEF_TIM(TIM3,  CH3, PB0,   TIM_USE_LED, 0, 8), // LED_2812
 };
 
 const int timerHardwareCount = sizeof(timerHardware) / sizeof(timerHardware[0]);


### PR DESCRIPTION
Sets LED DMA to 9. Needed to allow ADC and LED to work properly.
